### PR TITLE
[FEAT] 프로그램 상세페이지 수정 및 버블 섹션 구현

### DIFF
--- a/src/apis/programAPI.ts
+++ b/src/apis/programAPI.ts
@@ -53,4 +53,12 @@ export const programAPI = {
     const response = await authClient.get(`/api/programs/${type}/${id}`);
     return response.data;
   },
+  // 프로그램 신청
+  applyProgram: async (type: string, programId: string) => {
+    const response = await authClient.post(`/api/programs/apply`, {
+      type,
+      programId,
+    });
+    return response.data;
+  },
 };

--- a/src/apis/programAPI.ts
+++ b/src/apis/programAPI.ts
@@ -48,4 +48,9 @@ export const programAPI = {
     );
     return response.data;
   },
+  // 프로그램 상세페이지 조회
+  getProgramDetail: async (type: string, id: string) => {
+    const response = await authClient.get(`/api/programs/${type}/${id}`);
+    return response.data;
+  },
 };

--- a/src/components/DesignStartPage/DesignStartView.tsx
+++ b/src/components/DesignStartPage/DesignStartView.tsx
@@ -21,7 +21,7 @@ export const DesignStartView = () => {
                 어떤 브랜더가 되고 싶나요?
               </TitleContainer>
               <SubTitleContainer>
-                문항은 <span className="highlight">총 3문항</span>으로, 앞으로 만들어 갈 나의 브랜드
+                문항은 <span className="highlight">총 5문항</span>으로, 앞으로 만들어 갈 나의 브랜드
                 방향성을 설정하는 첫 걸음이에요.
                 <br />
                 설계하기 테스트를 통해 나의 브랜드 컨셉을 정해보고,{' '}

--- a/src/components/ExperienceDetailPage/BubbleSection.tsx
+++ b/src/components/ExperienceDetailPage/BubbleSection.tsx
@@ -1,3 +1,141 @@
-export const BubbleSection = () => {
-  return <div>여긴 버블버블</div>;
+import styled from 'styled-components';
+
+import { moveDown, moveLeft, moveRight, moveUp } from '@/styles';
+
+interface BubbleSectionProps {
+  keywords: string[];
+}
+
+export const BubbleSection = ({ keywords }: BubbleSectionProps) => {
+  return (
+    <StyledContainer>
+      <div className="title">
+        이런 <span className="highlight">이미지 키워드</span>의 사람이 선호하는 경험이에요.
+      </div>
+      <StyledBubbleContainer>
+        {keywords.map((keyword, index) => (
+          <StyledBubble
+            key={keyword}
+            className={`b${index}`}
+            $weight={1 - ((1 - 0.48) / (keywords.length - 1)) * index}
+          >
+            <span>{keyword}</span>
+          </StyledBubble>
+        ))}
+      </StyledBubbleContainer>
+    </StyledContainer>
+  );
 };
+
+const StyledContainer = styled.section`
+  width: 100%;
+
+  .title {
+    ${({ theme }) => theme.font.desktop.title1};
+    color: ${({ theme }) => theme.color.gray700};
+    margin-bottom: 24px;
+
+    .highlight {
+      color: ${({ theme }) => theme.color.primary500};
+    }
+  }
+`;
+
+const StyledBubbleContainer = styled.div`
+  height: 481px;
+  position: relative;
+
+  border-radius: 8px;
+  border: 2px solid ${({ theme }) => theme.color.primary100};
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 59.5%, #e1d1ff 100%), #fff;
+`;
+
+const StyledBubble = styled.div<{ $weight: number }>`
+  width: ${({ $weight }) => $weight * 270}px;
+  height: ${({ $weight }) => $weight * 270}px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  will-change: transform;
+
+  text-align: center;
+  color: ${({ theme }) => theme.color.primary800};
+  ${({ theme }) => theme.font.desktop.body1b};
+
+  position: absolute;
+
+  border-radius: 50%;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(255, 255, 255, 0) 76%,
+    rgba(204, 179, 253, 0.4) 100%
+  );
+
+  box-shadow:
+    -0.319px 51.263px 151.773px 0px rgba(48, 13, 115, 0.12),
+    -0.04px 6.444px 21.116px 0px rgba(48, 13, 115, 0.06);
+
+  &.b0 {
+    bottom: 10%;
+    left: 30%;
+
+    animation:
+      ${moveDown} 2000ms ease-in-out infinite,
+      ${moveLeft} 3000ms ease-in-out infinite;
+  }
+
+  &.b1 {
+    top: 12%;
+    right: 32%;
+
+    animation:
+      ${moveDown} 3000ms ease-in-out infinite,
+      ${moveRight} 2000ms ease-in-out infinite;
+  }
+
+  &.b2 {
+    bottom: 20%;
+    right: 17%;
+
+    animation:
+      ${moveUp} 2500ms ease-in-out infinite,
+      ${moveLeft} 3000ms ease-in-out infinite;
+  }
+
+  &.b3 {
+    top: 20%;
+    left: 20%;
+
+    animation:
+      ${moveUp} 2300ms ease-in-out infinite,
+      ${moveLeft} 2700ms ease-in-out infinite;
+  }
+
+  &.b4 {
+    top: 10%;
+    right: 14%;
+
+    animation:
+      ${moveDown} 2500ms ease-in-out infinite,
+      ${moveRight} 2300ms ease-in-out infinite;
+  }
+
+  &.b5 {
+    top: 20%;
+    left: 10%;
+
+    animation:
+      ${moveUp} 2600ms ease-in-out infinite,
+      ${moveRight} 3000ms ease-in-out infinite;
+  }
+
+  &.b6 {
+    bottom: 14%;
+    left: 20%;
+
+    animation:
+      ${moveDown} 3000ms ease-in-out infinite,
+      ${moveRight} 2800ms ease-in-out infinite;
+  }
+`;

--- a/src/components/ExperienceDetailPage/DetailSection.tsx
+++ b/src/components/ExperienceDetailPage/DetailSection.tsx
@@ -5,11 +5,11 @@ import { styled } from 'styled-components';
 import { PlainButton } from '@/components/common/Button/PlainButton';
 import { PlainChip } from '@/components/common/Chip/PlainChip';
 import { ExperienceDetailModal } from '@/components/common/Modal/ExperienceDetailModal';
-import { DetailData } from '@/pages/ExperienceDetailPage';
+import { ProgramDetailResult } from '@/types/program.type';
 
-const DetailSection = ({ data }: { data: DetailData | undefined }) => {
+const DetailSection = ({ data }: { data: ProgramDetailResult | undefined }) => {
   const [isModalOpen, setModalOpen] = useState(false);
-  const [participants, setParticipants] = useState(data ? data.participants : 0);
+  const [participants, setParticipants] = useState<number>(data ? data.participants : 0);
   const [isButtonDisabled, setButtonDisabled] = useState(false);
 
   useEffect(() => {
@@ -25,7 +25,7 @@ const DetailSection = ({ data }: { data: DetailData | undefined }) => {
   };
 
   const handleIncreaseParticipants = () => {
-    setParticipants((prevParticipants) => prevParticipants + 1);
+    setParticipants((prev) => prev + 1);
     setButtonDisabled(true);
     setModalOpen(false);
   };
@@ -34,24 +34,24 @@ const DetailSection = ({ data }: { data: DetailData | undefined }) => {
     return (
       <StyledContainer>
         <ProgramImageContainer>
-          <img src={data.imageURL} alt="Detail" />
+          <img src={data.imageUrl} alt="Detail" />
         </ProgramImageContainer>
         <DetailContainer>
           <TextContainer>
             <PlainChip primary={true} width="max-content">
               {participants}명 참여 중!
             </PlainChip>
-            <TitleContainer>{data.title}</TitleContainer>
-            <SubTitleContainer>{data.subtitle}</SubTitleContainer>
+            <TitleContainer>{data.name}</TitleContainer>
+            <SubTitleContainer>{data.oneLineDescription}</SubTitleContainer>
           </TextContainer>
           <ProfileContainer>
             <ProfileImageContainer>
-              <img src={data.profileImageURL} alt="profile" />
+              <img src={data.providerImage} alt="profile" />
             </ProfileImageContainer>
             <ProfileTextContainer>
               <ProfileTitleContainer>{data.providerName}</ProfileTitleContainer>
               <ProfileSubTitleContainer>
-                {data.providerJob} | {data.providerTitle} | {data.providerKeyword}
+                {data.providerJob} | {data.providerKeyword}
               </ProfileSubTitleContainer>
             </ProfileTextContainer>
           </ProfileContainer>

--- a/src/components/ExperienceDetailPage/DetailSection.tsx
+++ b/src/components/ExperienceDetailPage/DetailSection.tsx
@@ -2,15 +2,21 @@ import { useEffect, useState } from 'react';
 
 import { styled } from 'styled-components';
 
+import { programAPI } from '@/apis/programAPI';
 import { PlainButton } from '@/components/common/Button/PlainButton';
 import { PlainChip } from '@/components/common/Chip/PlainChip';
 import { ExperienceDetailModal } from '@/components/common/Modal/ExperienceDetailModal';
 import { ProgramDetailResult } from '@/types/program.type';
 
-const DetailSection = ({ data }: { data: ProgramDetailResult | undefined }) => {
+interface DetailSectionProps {
+  data: ProgramDetailResult | undefined;
+  programId: string;
+}
+
+const DetailSection = ({ data, programId }: DetailSectionProps) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [participants, setParticipants] = useState<number>(data ? data.participants : 0);
-  const [isButtonDisabled, setButtonDisabled] = useState(false);
+  const [isButtonDisabled, setButtonDisabled] = useState(data ? data.apply : false);
 
   useEffect(() => {
     if (data) setParticipants(data.participants);
@@ -25,9 +31,13 @@ const DetailSection = ({ data }: { data: ProgramDetailResult | undefined }) => {
   };
 
   const handleIncreaseParticipants = () => {
-    setParticipants((prev) => prev + 1);
-    setButtonDisabled(true);
-    setModalOpen(false);
+    if (data) {
+      programAPI.applyProgram(data.type, programId).then(() => {
+        setParticipants((prev) => prev + 1);
+        setButtonDisabled(true);
+        setModalOpen(false);
+      });
+    }
   };
 
   if (data)

--- a/src/components/ExperienceDetailPage/DetailSection.tsx
+++ b/src/components/ExperienceDetailPage/DetailSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { styled } from 'styled-components';
 
@@ -7,10 +7,14 @@ import { PlainChip } from '@/components/common/Chip/PlainChip';
 import { ExperienceDetailModal } from '@/components/common/Modal/ExperienceDetailModal';
 import { DetailData } from '@/pages/ExperienceDetailPage';
 
-const DetailSection = ({ data }: { data: DetailData }) => {
+const DetailSection = ({ data }: { data: DetailData | undefined }) => {
   const [isModalOpen, setModalOpen] = useState(false);
-  const [participants, setParticipants] = useState(data.participants);
+  const [participants, setParticipants] = useState(data ? data.participants : 0);
   const [isButtonDisabled, setButtonDisabled] = useState(false);
+
+  useEffect(() => {
+    if (data) setParticipants(data.participants);
+  }, [data]);
 
   const handleOpenModal = () => {
     setModalOpen(true);
@@ -26,60 +30,59 @@ const DetailSection = ({ data }: { data: DetailData }) => {
     setModalOpen(false);
   };
 
-  return (
-    <StyledContainer>
-      <ImageContainer>
-        <img src={data.imageURL} alt="Detail" />
-      </ImageContainer>
-      <DetailContainer>
-        <TextContainer>
-          <PlainChip primary={true}>{participants}명 참여 중!</PlainChip>
-          <TitleContainer>{data.title}</TitleContainer>
-          <SubTitleContainer>{data.subtitle}</SubTitleContainer>
-        </TextContainer>
-        <ProfileContainer>
-          <ProfileImageContainer>
-            <img src={data.profileImageURL} alt="profile" />
-          </ProfileImageContainer>
-          <ProfileTextContainer>
-            <ProfileTitleContainer>{data.providerName}</ProfileTitleContainer>
-            <ProfileSubTitleContainer>
-              {data.providerJob} | {data.providerTitle} | {data.providerKeyword}
-            </ProfileSubTitleContainer>
-          </ProfileTextContainer>
-        </ProfileContainer>
-        <PlainButton
-          variant="gray"
-          height="48px"
-          onClick={handleOpenModal}
-          disabled={isButtonDisabled}
-        >
-          신청하기
-        </PlainButton>
-      </DetailContainer>
-      <ExperienceDetailModal
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
-        onConfirm={handleIncreaseParticipants}
-      />
-    </StyledContainer>
-  );
+  if (data)
+    return (
+      <StyledContainer>
+        <ProgramImageContainer>
+          <img src={data.imageURL} alt="Detail" />
+        </ProgramImageContainer>
+        <DetailContainer>
+          <TextContainer>
+            <PlainChip primary={true} width="max-content">
+              {participants}명 참여 중!
+            </PlainChip>
+            <TitleContainer>{data.title}</TitleContainer>
+            <SubTitleContainer>{data.subtitle}</SubTitleContainer>
+          </TextContainer>
+          <ProfileContainer>
+            <ProfileImageContainer>
+              <img src={data.profileImageURL} alt="profile" />
+            </ProfileImageContainer>
+            <ProfileTextContainer>
+              <ProfileTitleContainer>{data.providerName}</ProfileTitleContainer>
+              <ProfileSubTitleContainer>
+                {data.providerJob} | {data.providerTitle} | {data.providerKeyword}
+              </ProfileSubTitleContainer>
+            </ProfileTextContainer>
+          </ProfileContainer>
+          <PlainButton
+            variant="gray"
+            width="100%"
+            height="48px"
+            onClick={handleOpenModal}
+            disabled={isButtonDisabled}
+          >
+            신청하기
+          </PlainButton>
+        </DetailContainer>
+        <ExperienceDetailModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          onConfirm={handleIncreaseParticipants}
+        />
+      </StyledContainer>
+    );
 };
 
 export default DetailSection;
 const StyledContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  justify-content: flex-start;
-  align-items: flex-start;
+  display: flex;
   gap: 32px;
-  display: inline-flex;
 `;
 
-const ImageContainer = styled.div`
+const ProgramImageContainer = styled.div`
   width: 597px;
   height: 373px;
-  position: relative;
   border-radius: 8px;
   overflow: hidden;
   flex-shrink: 0;
@@ -88,62 +91,56 @@ const ImageContainer = styled.div`
     width: 100%;
     height: 100%;
     object-fit: cover;
-    border-radius: 8px;
   }
 `;
 
 const DetailContainer = styled.div`
-  flex: 1 1 0;
-  align-self: stretch;
+  flex: 1;
+  display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
   gap: 16px;
-  display: inline-flex;
 `;
 
 const TextContainer = styled.div`
-  align-self: stretch;
   flex: 1 1 0;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 10px;
+
   display: flex;
+  flex-direction: column;
+  gap: 10px;
 `;
 
 const TitleContainer = styled.div`
-  align-self: stretch;
   color: ${({ theme }) => `${theme.color.gray700}`};
   ${({ theme }) => theme.font.desktop.title1};
+  word-break: break-word;
+  overflow-wrap: break-word;
 `;
 
 const SubTitleContainer = styled.div`
-  align-self: stretch;
   color: ${({ theme }) => `${theme.color.gray500}`};
   ${({ theme }) => theme.font.desktop.body2m};
+  word-break: break-word;
+  overflow-wrap: break-word;
 `;
 
 const ProfileContainer = styled.div`
-  align-self: stretch;
   padding: 16px;
   background-color: ${({ theme }) => `${theme.color.white}`};
   border-radius: 8px;
-  overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: break-word;
   border: 2px solid ${({ theme }) => `${theme.color.gray150}`};
-  justify-content: flex-start;
-  align-items: center;
+
+  display: flex;
   gap: 16px;
-  display: inline-flex;
-  flex-shrink: 0;
 `;
 
 const ProfileImageContainer = styled.div`
   width: 56px;
   height: 56px;
-  background: linear-gradient(0deg, #f4efff 0%, #f4efff 100%);
   border-radius: 8px;
   overflow: hidden;
+  flex-shrink: 0;
 
   img {
     width: 100%;
@@ -153,11 +150,12 @@ const ProfileImageContainer = styled.div`
 `;
 
 const ProfileTextContainer = styled.div`
+  word-wrap: break-all;
+  overflow-wrap: break-word;
+
+  display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
   gap: 4px;
-  display: inline-flex;
 `;
 
 const ProfileTitleContainer = styled.div`
@@ -166,6 +164,10 @@ const ProfileTitleContainer = styled.div`
 `;
 
 const ProfileSubTitleContainer = styled.div`
+  width: 100%;
+  text-overflow: ellipsis;
+  word-break: break-word;
+  overflow-wrap: break-word;
   color: ${({ theme }) => `${theme.color.gray700}`};
   ${({ theme }) => theme.font.desktop.body2m};
 `;

--- a/src/components/ExperienceDetailPage/ImageSection.tsx
+++ b/src/components/ExperienceDetailPage/ImageSection.tsx
@@ -1,18 +1,7 @@
 import { styled } from 'styled-components';
 
-import { Dummy1 } from '@/pages/ExperienceDetailPage';
-
-export const ImageSection = () => {
-  return (
-    <StyledContainer>
-      <TitleContainer>프로그램 소개</TitleContainer>
-      <ImageBorderContainer>
-        <ImageContainer>
-          <img src={Dummy1.imageURL} alt="Detail" />
-        </ImageContainer>
-      </ImageBorderContainer>
-    </StyledContainer>
-  );
+export const ImageSection = ({ description }: { description: string | undefined }) => {
+  return <StyledContainer>{description && <img src={description} alt="Detail" />}</StyledContainer>;
 };
 
 const StyledContainer = styled.div`
@@ -23,28 +12,4 @@ const StyledContainer = styled.div`
   align-items: flex-start;
   gap: 24px;
   display: inline-flex;
-`;
-
-const TitleContainer = styled.div`
-  text-align: center;
-  color: ${({ theme }) => `${theme.color.gray900}`};
-  ${({ theme }) => theme.font.desktop.title1};
-`;
-
-const ImageBorderContainer = styled.div`
-  align-self: stretch;
-  padding: 32px;
-  background-color: ${({ theme }) => `${theme.color.white}`};
-  border-radius: 8px;
-  overflow: hidden;
-  border: 2px solid ${({ theme }) => `${theme.color.gray150}`};
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 20px;
-  display: flex;
-`;
-
-const ImageContainer = styled.div`
-  //연동하면서 수정 예정
 `;

--- a/src/components/HomePage/PieceSection.tsx
+++ b/src/components/HomePage/PieceSection.tsx
@@ -1,11 +1,11 @@
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 
 import { ReactComponent as ArrowIcon } from '@/assets/icons/arrowDown.svg';
 import { PlainChip } from '@/components/common/Chip/PlainChip';
 import { CARD_IMAGE } from '@/constants/card';
 import { PERSONA } from '@/constants/persona';
 import { userService } from '@/services/UserService';
-import { SectionContainer } from '@/styles';
+import { SectionContainer, moveDown, moveLeft, moveRight, moveUp } from '@/styles';
 import { DefineResult } from '@/types/test.type';
 
 interface PieceSectionProps {
@@ -106,26 +106,6 @@ const StyledCardContainer = styled.div`
     border-radius: 13px;
   }
 `;
-
-const moveDown = keyframes`
-  50% {
-    transform: translateY(-20px);
-  }`;
-
-const moveUp = keyframes`
-  50% {
-    transform: translateY(20px);
-  }`;
-
-const moveRight = keyframes`
-  50% {
-    transform: translateX(20px);
-  }`;
-
-const moveLeft = keyframes`
-  50% {
-    transform: translateX(-20px);
-  }`;
 
 const StyledBubble = styled.div<{ $weight: number }>`
   width: ${({ $weight }) => $weight * 360}px;

--- a/src/components/common/Button/PlainButton.tsx
+++ b/src/components/common/Button/PlainButton.tsx
@@ -82,5 +82,6 @@ const StyledButton = styled.button<StyledButtonProps>`
   &:disabled {
     color: ${(props) => props.theme.color.gray700};
     background: ${(props) => props.theme.color.gray200};
+    cursor: default;
   }
 `;

--- a/src/components/common/Chip/PlainChip.tsx
+++ b/src/components/common/Chip/PlainChip.tsx
@@ -2,16 +2,22 @@ import styled, { css } from 'styled-components';
 
 interface PlainChipProps {
   primary?: boolean;
+  width?: string;
   children: React.ReactNode;
 }
 
-export const PlainChip = ({ primary = false, children }: PlainChipProps) => {
-  return <StyledContainer $primary={primary}>{children}</StyledContainer>;
+export const PlainChip = ({ primary = false, width, children }: PlainChipProps) => {
+  return (
+    <StyledContainer $primary={primary} $width={width}>
+      {children}
+    </StyledContainer>
+  );
 };
 
-const StyledContainer = styled.div<{ $primary: boolean }>`
+const StyledContainer = styled.div<{ $primary: boolean; $width?: string }>`
   ${({ theme }) => theme.font.desktop.body1m};
 
+  width: ${(props) => props.$width || 'auto'};
   height: 42px;
   padding: 0 16px;
   border-radius: 8px;

--- a/src/components/common/Layout/TestLayout.tsx
+++ b/src/components/common/Layout/TestLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
-import TestNavigation from '@/components/common/Navigation/TestNavigation';
+import { TestNavigation } from '@/components/common/Navigation/TestNavigation';
 
 export const TestLayout = () => {
   return (

--- a/src/components/common/Modal/DefaultModal.tsx
+++ b/src/components/common/Modal/DefaultModal.tsx
@@ -56,4 +56,6 @@ const StyledModalContainer = styled.div<{ $width: string; $height: string }>`
 
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(4px);
 `;

--- a/src/components/common/Modal/ExperienceDetailModal.tsx
+++ b/src/components/common/Modal/ExperienceDetailModal.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { PlainButton } from '@/components/common/Button/PlainButton';
+import { DefaultModal } from '@/components/common/Modal/DefaultModal';
 
 interface ModalProps {
   isOpen: boolean;
@@ -24,51 +25,31 @@ export const ExperienceDetailModal = ({ isOpen, onClose, onConfirm }: ModalProps
   if (!isOpen) return null;
 
   return (
-    <ModalOverlay>
-      <ModalContent>
+    <DefaultModal>
+      <ContentContainer>
         <TitleContainer>프로그램 신청</TitleContainer>
-        <ContentContainer>
+        <DescriptionContainer>
           해당 프로그램을 <Highlight>신청</Highlight>하시겠습니까?
-        </ContentContainer>
+        </DescriptionContainer>
         <ButtonContainer>
-          <StyledButton height="48px" onClick={onClose}>
+          <PlainButton variant="disabled" height="48px" onClick={onClose}>
             취소하기
-          </StyledButton>
+          </PlainButton>
           <PlainButton variant="gray" height="48px" onClick={onConfirm}>
             신청하기
           </PlainButton>
         </ButtonContainer>
-      </ModalContent>
-    </ModalOverlay>
+      </ContentContainer>
+    </DefaultModal>
   );
 };
 
-const ModalOverlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
+const ContentContainer = styled.div`
   height: 100%;
-  background: rgba(17.85, 17.85, 17.85, 0.36);
-  backdrop-filter: blur(10px);
   display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const ModalContent = styled.div`
-  width: 618px;
-  height: 338px;
-  background: white;
-  padding: 24px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
-  border-radius: 16px;
-  overflow: hidden;
-  backdrop-filter: blur(8px);
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  display: inline-flex;
 `;
 
 const TitleContainer = styled.div`
@@ -78,7 +59,7 @@ const TitleContainer = styled.div`
   ${({ theme }) => theme.font.desktop.body1b};
 `;
 
-const ContentContainer = styled.div`
+const DescriptionContainer = styled.div`
   color: ${({ theme }) => `${theme.color.gray700}`};
   ${({ theme }) => theme.font.desktop.title2};
 `;
@@ -88,14 +69,6 @@ const ButtonContainer = styled.div`
   justify-content: flex-start;
   gap: 8px;
   display: inline-flex;
-`;
-
-const StyledButton = styled(PlainButton)`
-  background: ${({ theme }) => `${theme.color.gray200}`};
-  &:hover {
-    background: ${({ theme }) => `${theme.color.gray200}`};
-  }
-  color: inherit;
 `;
 
 const Highlight = styled.span`

--- a/src/components/common/Navigation/TestNavigation.tsx
+++ b/src/components/common/Navigation/TestNavigation.tsx
@@ -1,5 +1,32 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+
+const NAVIGATION_LIST: { [key: string]: string } = {
+  define: 'Define 정의하기',
+  design: 'Design 설계하기',
+  discover: 'Discover 이해하기',
+};
+
+export const TestNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleButtonClick = () => {
+    navigate('/understand');
+  };
+
+  const currentKey = Object.keys(NAVIGATION_LIST).find((key) => location.pathname.includes(key));
+  const currentTitle = currentKey ? NAVIGATION_LIST[currentKey] : '';
+
+  return (
+    <StyledContainer>
+      <Container>
+        <Title>{currentTitle}</Title>
+        <StyledButton onClick={handleButtonClick}>종료하기</StyledButton>
+      </Container>
+    </StyledContainer>
+  );
+};
 
 const StyledContainer = styled.header`
   display: flex;
@@ -69,21 +96,3 @@ const StyledButton = styled.button`
     ${({ theme }) => theme.font.mobile.body1b};
   }
 `;
-
-const TestNavigation = () => {
-  const navigate = useNavigate();
-
-  const handleButtonClick = () => {
-    navigate('/understand');
-  };
-  return (
-    <StyledContainer>
-      <Container>
-        <Title>Define 정의하기</Title>
-        <StyledButton onClick={handleButtonClick}>종료하기</StyledButton>
-      </Container>
-    </StyledContainer>
-  );
-};
-
-export default TestNavigation;

--- a/src/pages/ExperienceDetailPage.tsx
+++ b/src/pages/ExperienceDetailPage.tsx
@@ -3,55 +3,34 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { authClient } from '@/apis/client';
+import { programAPI } from '@/apis/programAPI';
 import { BubbleSection } from '@/components/ExperienceDetailPage/BubbleSection';
 import DetailSection from '@/components/ExperienceDetailPage/DetailSection';
 import { ImageSection } from '@/components/ExperienceDetailPage/ImageSection';
-
-export interface DetailData {
-  imageURL: string;
-  profileImageURL: string;
-  participants: number;
-  title: string;
-  subtitle: string;
-  providerName: string;
-  providerJob: string;
-  providerTitle: string;
-  providerKeyword: string;
-  programURL: string;
-}
+import { ProgramDetailResult } from '@/types/program.type';
 
 export const ExperienceDetailPage = () => {
-  const { id } = useParams<{ id: string }>();
-  const [data, setData] = useState<DetailData | undefined>(undefined);
+  const { type, id } = useParams();
+  const [data, setData] = useState<ProgramDetailResult | undefined>(undefined);
   const [keywords, setKeywords] = useState([]);
+  const [description, setDescription] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     const detailData = async () => {
       try {
-        const response = await authClient.get(`/api/programs/branding/${id}`);
-        const apiData = response.data.payload;
-        const formattedData: DetailData = {
-          imageURL: apiData.imageUrl,
-          profileImageURL: apiData.providerImage,
-          participants: apiData.participants,
-          title: apiData.name,
-          subtitle: apiData.oneLineDescription,
-          providerName: apiData.providerName,
-          providerJob: apiData.providerJob,
-          providerTitle: apiData.name,
-          providerKeyword: apiData.keywords.join(', '),
-          programURL: apiData.link,
-        };
-        setData(formattedData);
-        setKeywords(apiData.keywords);
+        if (type && id) {
+          const response = await programAPI.getProgramDetail(type, id);
+          setData(response.payload);
+          setKeywords(response.payload.keywords);
+          setDescription(response.payload.descriptionUrl);
+        }
       } catch (error) {
         console.error(error);
       }
     };
 
     detailData();
-  }, [id]);
+  }, [type, id]);
 
   if (!data)
     return (
@@ -64,7 +43,7 @@ export const ExperienceDetailPage = () => {
       <StyledInnerContainer>
         <DetailSection data={data} />
         <BubbleSection keywords={keywords} />
-        <ImageSection />
+        <ImageSection description={description} />
       </StyledInnerContainer>
     </StyledContainer>
   );

--- a/src/pages/ExperienceDetailPage.tsx
+++ b/src/pages/ExperienceDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { programAPI } from '@/apis/programAPI';
@@ -14,6 +14,7 @@ export const ExperienceDetailPage = () => {
   const [data, setData] = useState<ProgramDetailResult | undefined>(undefined);
   const [keywords, setKeywords] = useState([]);
   const [description, setDescription] = useState<string | undefined>(undefined);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const detailData = async () => {
@@ -26,6 +27,9 @@ export const ExperienceDetailPage = () => {
         }
       } catch (error) {
         console.error(error);
+        window.alert('프로그램 정보를 불러오는데 실패했습니다.');
+        // 프로그램 페이지로 이동
+        navigate('/program');
       }
     };
 

--- a/src/pages/ExperienceDetailPage.tsx
+++ b/src/pages/ExperienceDetailPage.tsx
@@ -36,19 +36,20 @@ export const ExperienceDetailPage = () => {
     detailData();
   }, [type, id]);
 
-  if (!data)
+  if (data && id)
     return (
       <StyledContainer>
-        <StyledInnerContainer>Loading...</StyledInnerContainer>
+        <StyledInnerContainer>
+          <DetailSection data={data} programId={id} />
+          <BubbleSection keywords={keywords} />
+          <ImageSection description={description} />
+        </StyledInnerContainer>
       </StyledContainer>
     );
+
   return (
     <StyledContainer>
-      <StyledInnerContainer>
-        <DetailSection data={data} />
-        <BubbleSection keywords={keywords} />
-        <ImageSection description={description} />
-      </StyledInnerContainer>
+      <StyledInnerContainer>Loading...</StyledInnerContainer>
     </StyledContainer>
   );
 };

--- a/src/pages/ExperienceDetailPage.tsx
+++ b/src/pages/ExperienceDetailPage.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { authClient } from '@/apis/client';
-import TestImage from '@/assets/test1.png';
 import { BubbleSection } from '@/components/ExperienceDetailPage/BubbleSection';
 import DetailSection from '@/components/ExperienceDetailPage/DetailSection';
 import { ImageSection } from '@/components/ExperienceDetailPage/ImageSection';
@@ -24,7 +23,8 @@ export interface DetailData {
 
 export const ExperienceDetailPage = () => {
   const { id } = useParams<{ id: string }>();
-  const [data, setData] = useState<DetailData>(Dummy1);
+  const [data, setData] = useState<DetailData | undefined>(undefined);
+  const [keywords, setKeywords] = useState([]);
 
   useEffect(() => {
     const detailData = async () => {
@@ -44,6 +44,7 @@ export const ExperienceDetailPage = () => {
           programURL: apiData.link,
         };
         setData(formattedData);
+        setKeywords(apiData.keywords);
       } catch (error) {
         console.error(error);
       }
@@ -52,37 +53,34 @@ export const ExperienceDetailPage = () => {
     detailData();
   }, [id]);
 
+  if (!data)
+    return (
+      <StyledContainer>
+        <StyledInnerContainer>Loading...</StyledInnerContainer>
+      </StyledContainer>
+    );
   return (
     <StyledContainer>
-      <DetailSection data={data} />
-      <BubbleSection />
-      <ImageSection />
+      <StyledInnerContainer>
+        <DetailSection data={data} />
+        <BubbleSection keywords={keywords} />
+        <ImageSection />
+      </StyledInnerContainer>
     </StyledContainer>
   );
 };
 
 const StyledContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  padding: 64px 56px;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 72px;
-  display: inline-flex;
-  padding-top: 142px;
+  min-width: 1280px;
+  padding-top: 76px;
 `;
 
-export const Dummy1: DetailData = {
-  imageURL: TestImage, //imageUrl
-  profileImageURL: TestImage, //providerUrl
-  participants: 28,
-  title: '퍼스널 브랜딩, ‘나’를 기획, 디자인하기', //name
-  subtitle:
-    '대한민국은 국제평화의 유지에 노력하고 침략적 전쟁을 부인한다. 국민의 모든 자유와 권리는 국가안전보장·질서유지 또는 공공복리를 위하여 필요한 경우에 한하여 법률로써 제한할 수 있으며.대한민국은 국제평화의 유지에 노력하고 침략적 전쟁을 부인한다.', //on
-  providerName: '신민선',
-  providerJob: '콘텐츠 마케터',
-  providerTitle: '퍼스널브랜딩',
-  providerKeyword: '어쩌구',
-  programURL: TestImage,
-};
+const StyledInnerContainer = styled.div`
+  width: 1280px;
+  padding: 56px; 64px;
+  margin: 0 auto;
+
+  display: flex;
+  flex-direction: column;
+  gap: 72px;
+`;

--- a/src/routers/router.tsx
+++ b/src/routers/router.tsx
@@ -32,11 +32,9 @@ export const Router = () => {
           <Route path="/" element={<HomePage />} />
           <Route path="/auth" element={<LoginPage />} />
           <Route path="/understand" element={<SelfUnderstandPage />} />
-          {/* <Route path="/recommend/:id" element={<ExperienceDetailPage />} /> */}
-          <Route path="/program/:type/:id" element={<ExperienceDetailPage />} />
-          {/* <Route element={<MemberPrivateRoute />}>
-            <Route path="/mypage" element={<MyPage />} />
-          </Route> */}
+          <Route element={<MemberPrivateRoute />}>
+            <Route path="/program/:type/:id" element={<ExperienceDetailPage />} />
+          </Route>
         </Route>
       </Route>
       <Route path="test" element={<TestLayout />}>

--- a/src/routers/router.tsx
+++ b/src/routers/router.tsx
@@ -32,7 +32,8 @@ export const Router = () => {
           <Route path="/" element={<HomePage />} />
           <Route path="/auth" element={<LoginPage />} />
           <Route path="/understand" element={<SelfUnderstandPage />} />
-          <Route path="/recommend/:id" element={<ExperienceDetailPage />} />
+          {/* <Route path="/recommend/:id" element={<ExperienceDetailPage />} /> */}
+          <Route path="/program/:type/:id" element={<ExperienceDetailPage />} />
           {/* <Route element={<MemberPrivateRoute />}>
             <Route path="/mypage" element={<MyPage />} />
           </Route> */}

--- a/src/styles/global/GlobalStyle.ts
+++ b/src/styles/global/GlobalStyle.ts
@@ -1,4 +1,4 @@
-import styled, { createGlobalStyle } from 'styled-components';
+import styled, { createGlobalStyle, keyframes } from 'styled-components';
 import reset from 'styled-reset';
 
 export const GlobalStyle = createGlobalStyle`
@@ -74,3 +74,23 @@ export const SectionContainer = styled.div`
   width: 1280px;
   margin: 0 auto;
 `;
+
+export const moveDown = keyframes`
+  50% {
+    transform: translateY(-20px);
+  }`;
+
+export const moveUp = keyframes`
+  50% {
+    transform: translateY(20px);
+  }`;
+
+export const moveRight = keyframes`
+  50% {
+    transform: translateX(20px);
+  }`;
+
+export const moveLeft = keyframes`
+  50% {
+    transform: translateX(-20px);
+  }`;

--- a/src/types/program.type.ts
+++ b/src/types/program.type.ts
@@ -9,3 +9,19 @@ export interface RecommendProgramItem {
   price: number;
   keywords: string[];
 }
+
+export interface ProgramDetailResult {
+  imageUrl: string;
+  name: string;
+  oneLineDescription: string;
+  price: number;
+  form: string | null;
+  descriptionUrl: string;
+  link: string;
+  keywords: string[];
+  participants: number;
+  providerImage: string;
+  providerName: string;
+  providerJob: string;
+  providerKeyword: string;
+}

--- a/src/types/program.type.ts
+++ b/src/types/program.type.ts
@@ -24,4 +24,6 @@ export interface ProgramDetailResult {
   providerName: string;
   providerJob: string;
   providerKeyword: string;
+  type: string;
+  apply: boolean;
 }


### PR DESCRIPTION
## 1️⃣ 요약

- 프로그램 소개 섹션의 구조를 수정했습니다.
- 프로그램 상세페이지 내 버블 섹션을 구현했습니다.
- 프로그램 상세 설명 이미지 섹션을 구현했습니다.
- resolved #61

## 2️⃣ 변경사항

### 기존 코드에 영향을 미치는 변경사항

- 라우팅을 수정했습니다.
- 전체적인 구조 수정을 진행했습니다. 
  - 프로그램 상세 조회 api의 데이터 구조에 맞춰 데이터 구조 및 타입을 수정했습니다.
  - 프로그램 설명 세션에서 피그마와 디자인 차이가 발생하는 부분을 수정했습니다.
- 이미지 세션도 추가로 구현했습니다.
- QA도 조금씩 반영했습니다.

### 기존 코드에 영향을 미치지 않는 변경사항

### 버그 수정을 위한 변경사항

## 3️⃣ 참고사항

- 제가 라우팅을 전체적으로 수정했어요.
  - recommend라는 path보다는 program이라는 path가 더 적절하다고 생각되어 이를 수정했습니다.
  - 프로그램 상세 조회 api를 확인하니까 branding 혹은 self-understand라는 타입도 params로 넘겨야하는 것을 확인했습니다. 그래서 `/program/{type}/{id}`로 진행하는 것이 좋을 것 같아 수정했습니다. 프로그램 목록 조회 페이지를 구현하실 때 `recommend` -> `program` 수정 어떠신가요?
  - 만약 이렇게 진행한다면 프로그램 상세 페이지로 이동 주소에 신경쓰면 좋을 것 같습니다.

## 4️⃣ 추후 작업

## 5️⃣ 리뷰 요구사항
